### PR TITLE
Remove ColorTemperature from HK output for color lights.

### DIFF
--- a/nodes/in.js
+++ b/nodes/in.js
@@ -261,7 +261,7 @@ module.exports = function(RED) {
                     }
 
                     //colors
-                    // if (state['colormode'] === 'hs' || state['colormode'] === 'xy') {
+                    if (state['colormode'] === 'hs' || state['colormode'] === 'xy') {
                         if (state['hue'] !== undefined) {
                             characteristic.Hue = DeconzHelper.convertRange(state['hue'], [0, 65535], [0, 360]);
                             if (no_reponse) characteristic.Hue = "NO_RESPONSE";
@@ -272,12 +272,12 @@ module.exports = function(RED) {
                             if (no_reponse) characteristic.Saturation = "NO_RESPONSE";
                         }
 
-                    // } else if (state['colormode'] === 'ct') {
+                    } else if (state['colormode'] === 'ct') {
                         if (state['ct'] !== undefined) { //lightbulb bug: use hue or ct
                             characteristic.ColorTemperature = DeconzHelper.convertRange(state['ct'], [153, 500], [140, 500]);
                             if (no_reponse) characteristic.ColorTemperature = "NO_RESPONSE";
                         }
-                    // }
+                    }
 
                 }
             }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
     "type": "git",
     "url": "git+https://github.com/andreypopov/node-red-contrib-deconz.git"
   },
-  "version": "1.1.14"
+  "version": "1.1.15"
 }


### PR DESCRIPTION
When we send ColorTemperature with Hue, Saturation and Brightness to a HomeKit node, there is a color presets bug in the HomeKit. When you select a preset it change color to previous. 